### PR TITLE
Fix PR, Update dependencies. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
         maven(url = "https://maven.pkg.jetbrains.space/public/p/compose/dev")
         maven(url = "https://dl.bintray.com/kotlin/dokka")
         maven(url = "https://kotlin.bintray.com/ktor")
@@ -114,8 +115,8 @@ allprojects {
                     url = if (version.toString().endsWith("SNAPSHOT")) uri(snapshotsRepoUrl) else uri(releasesRepoUrl)
 
                     credentials {
-                        username = rootProject.ext["ossrh.username"] as String
-                        password = rootProject.ext["ossrh.password"] as String
+                        username = rootProject.ext["ossrh.username"] as String? ?: ""
+                        password = rootProject.ext["ossrh.password"] as String? ?: ""
                     }
 
                 }
@@ -135,7 +136,7 @@ allprojects {
 
 nexusStaging {
     packageGroup = Kamel.Group
-    stagingProfileId = rootProject.ext["stagingProfileId"] as String
-    username = rootProject.ext["ossrh.username"] as String
-    password = rootProject.ext["ossrh.password"] as String
+    stagingProfileId = rootProject.ext["stagingProfileId"] as String? ?: ""
+    username = rootProject.ext["ossrh.username"] as String? ?: ""
+    password = rootProject.ext["ossrh.password"] as String? ?: ""
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,7 +29,7 @@ object Dependencies {
 
 private object Versions {
 
-    const val Kotlin = "1.6.21"
+    const val Kotlin = "1.6.10"
     const val Ktor = "2.0.2"
     const val Coroutines = "1.6.2"
     const val Compose = "1.1.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,11 +29,11 @@ object Dependencies {
 
 private object Versions {
 
-    const val Kotlin = "1.6.10"
-    const val Ktor = "2.0.0"
-    const val Coroutines = "1.6.0"
-    const val Compose = "1.0.1"
-    const val AGP = "7.1.3"
+    const val Kotlin = "1.6.21"
+    const val Ktor = "2.0.2"
+    const val Coroutines = "1.6.2"
+    const val Compose = "1.1.1"
+    const val AGP = "7.0.4"
 
     object Android {
         const val Appcompat = "1.4.1"

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -10,10 +10,10 @@ inline val PluginDependenciesSpec.multiplatform: PluginDependencySpec
     get() = kotlin("multiplatform")
 
 inline val PluginDependenciesSpec.`nexus-staging`: PluginDependencySpec
-    get() = id("io.codearte.nexus-staging") version "0.22.0"
+    get() = id("io.codearte.nexus-staging") version "0.30.0"
 
 inline val PluginDependenciesSpec.dokka: PluginDependencySpec
-    get() = id("org.jetbrains.dokka") version "1.4.20"
+    get() = id("org.jetbrains.dokka") version "1.6.21"
 
 inline val PluginDependenciesSpec.`android-library`: PluginDependencySpec
     get() = id("com.android.library")

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -13,7 +13,7 @@ inline val PluginDependenciesSpec.`nexus-staging`: PluginDependencySpec
     get() = id("io.codearte.nexus-staging") version "0.30.0"
 
 inline val PluginDependenciesSpec.dokka: PluginDependencySpec
-    get() = id("org.jetbrains.dokka") version "1.6.21"
+    get() = id("org.jetbrains.dokka") version "1.6.10"
 
 inline val PluginDependenciesSpec.`android-library`: PluginDependencySpec
     get() = id("com.android.library")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Aug 05 13:20:35 TRT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/kamel-core/build.gradle.kts
+++ b/kamel-core/build.gradle.kts
@@ -51,7 +51,7 @@ kotlin {
 
         all {
             languageSettings.apply {
-                useExperimentalAnnotation("kotlin.Experimental")
+                optIn("kotlin.Experimental")
             }
         }
 

--- a/kamel-core/src/commonMain/kotlin/io/kamel/core/fetcher/HttpFetcher.kt
+++ b/kamel-core/src/commonMain/kotlin/io/kamel/core/fetcher/HttpFetcher.kt
@@ -4,9 +4,9 @@ import io.kamel.core.DataSource
 import io.kamel.core.Resource
 import io.kamel.core.config.ResourceConfig
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/kamel-image/src/androidMain/kotlin/io/kamel/image/fetcher/ResourcesFetcher.kt
+++ b/kamel-image/src/androidMain/kotlin/io/kamel/image/fetcher/ResourcesFetcher.kt
@@ -22,7 +22,6 @@ internal class ResourcesFetcher(private val context: Context) : Fetcher<Url> {
     override val Url.isSupported: Boolean
         get() = protocol.name == ContentResolver.SCHEME_ANDROID_RESOURCE
 
-    @OptIn(ExperimentalIoApi::class)
     override fun fetch(
         data: Url,
         resourceConfig: ResourceConfig

--- a/kamel-image/src/androidMain/kotlin/io/kamel/image/mapper/ResourcesIdMapper.kt
+++ b/kamel-image/src/androidMain/kotlin/io/kamel/image/mapper/ResourcesIdMapper.kt
@@ -7,13 +7,13 @@ import io.kamel.core.mapper.Mapper
 import io.ktor.http.*
 
 
-internal class ResourcesIdMapper(private val context: Context) : Mapper<@DrawableRes Int, Url> {
+internal class ResourcesIdMapper(private val context: Context) : Mapper<@receiver:DrawableRes Int, Url> {
 
     override fun map(@DrawableRes input: Int): Url {
         val packageName = context.packageName
         val protocol = URLProtocol(name = ContentResolver.SCHEME_ANDROID_RESOURCE, defaultPort = -1)
 
-        return URLBuilder(protocol = protocol, host = packageName, encodedPath = input.toString())
+        return URLBuilder(protocol = protocol, host = packageName, pathSegments = listOf(input.toString()))
             .build()
     }
 }


### PR DESCRIPTION
There was a bunch of build issues with your PR. If fixed the build and further updated ktor and plugins

Edit:

If you build as is:
1. `gradlePluginPortal()` isn't added to `buildscript.repositories` and it fails there
2. Build fails if extra publishing properties aren't present (which isn't necessarily a bug, but it's easy enough to fix by doing ` as String` -> ` as String? ?: ""`)
3. The error: Minimum supported Gradle version is 7.2. Current version is 7.1.1. (I updated to 7.4.2)
4. `bodyAsChannel()` uses the wrong import in `HttpFetcher`
5. 
```
> Task :kamel-image:compileDebugKotlinAndroid FAILED
e: /Users/lucaspinazzola/Projects/Kamel/kamel-image/src/androidMain/kotlin/io/kamel/image/fetcher/ResourcesFetcher.kt: (25, 12): Unresolved reference: ExperimentalIoApi
e: /Users/lucaspinazzola/Projects/Kamel/kamel-image/src/androidMain/kotlin/io/kamel/image/fetcher/ResourcesFetcher.kt: (25, 12): An annotation argument must be a compile-time constant
e: /Users/lucaspinazzola/Projects/Kamel/kamel-image/src/androidMain/kotlin/io/kamel/image/mapper/ResourcesIdMapper.kt: (10, 73): This annotation is not applicable to target 'type usage'
e: /Users/lucaspinazzola/Projects/Kamel/kamel-image/src/androidMain/kotlin/io/kamel/image/mapper/ResourcesIdMapper.kt: (16, 68): Cannot find a parameter with this name: encodedPath
```
6. android gradle plugin `7.1.3` fails with a strange must use a different android studio version.. I downgraded back to `7.0.4`, which is what all `compose-jb` examples use
